### PR TITLE
fix OSGi problem in AbstractCalendarValidatorFacto

### DIFF
--- a/src/main/java/net/fortuna/ical4j/validate/AbstractCalendarValidatorFactory.java
+++ b/src/main/java/net/fortuna/ical4j/validate/AbstractCalendarValidatorFactory.java
@@ -9,7 +9,7 @@ public abstract class AbstractCalendarValidatorFactory {
 
     private static CalendarValidatorFactory instance;
     static {
-        instance = ServiceLoader.load(CalendarValidatorFactory.class).iterator().next();
+        instance = ServiceLoader.load(CalendarValidatorFactory.class, DefaultCalendarValidatorFactory.class.getClassLoader()).iterator().next();
     }
 
     public static CalendarValidatorFactory getInstance() {


### PR DESCRIPTION
set classloader explicitly in AbstractCalendarValidatorFactory to avoid issues with OSGi.

Similar workaround to https://github.com/ical4j/ical4j/pull/80/commits/f89a26341d90dda85dd13beaf1d02a61d9eeb2f7
Should fix https://github.com/ical4j/ical4j/issues/143